### PR TITLE
Fixed ASTERISK_PERIOD without brackets

### DIFF
--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -201,6 +201,7 @@ class HclParser(object):
         objectitem : objectkey EQUAL number
                    | objectkey EQUAL BOOL
                    | objectkey EQUAL STRING
+                   | objectkey EQUAL IDENTIFIER ASTERISK_PERIOD IDENTIFIER
                    | objectkey EQUAL IDENTIFIER
                    | objectkey EQUAL object
                    | objectkey EQUAL objectkey

--- a/tests/lex-fixtures/terraform0.12syntax.hcl
+++ b/tests/lex-fixtures/terraform0.12syntax.hcl
@@ -31,3 +31,7 @@ resource "aws_lambda_function" "github_collector" {
     }
   }
 }
+
+output "hostname" {
+  value = openstack_compute_instance_v2.instance.*.name
+}


### PR DESCRIPTION
New version of Terraform provides new api for `Working with count on resources`

According to documentation [here](https://www.terraform.io/upgrade-guides/0-12.html) we can specify * instead of count.index. 

pyhcl lib works only if ASTERISK_PERIOD is between brackets.